### PR TITLE
chore: Git のコミットメッセージテンプレートを Conventional Commits に準拠した形式に変更

### DIFF
--- a/tools/git/message
+++ b/tools/git/message
@@ -1,19 +1,14 @@
-# ==================== Format ====================
-:emoji: Subject
+type: Subject
 
-# ==================== Emojis ====================
-# ✨  :sparkles: 新機能追加（New Feature）
-# 🎉  :tada: 大きな機能追加（Big New Feature）
-# 👍  :+1: 機能改善（Update）
-# 🐛  :bug: バグ修正（Bugfix）
-# ♻  :recycle: リファクタリング(Refactoring)
-# 📚  :books: ドキュメント修正（Documentation）
-# 🎨  :art: デザインUI/UX(Accessibility)
-# 🚀  :rocket: パフォーマンス改善（Performance）
-# 🔧  :wrench: ツール（Tooling）
-# 💚  :green_heart: テスト/CI（Tests/CI）
-# 💩  :hankey: 非推奨追加（Deprecation）
-# 🗑️  :wastebasket: 削除（Removal）
-# 🆙  :up: ライブラリアップデート(Library Update)
-# 🚧  :construction: WIP(Work In Progress)
-# 🔖  :bookmark: バージョンタグ（Version Tag）
+# ==================== Types ====================
+# ✨ feat: 新機能
+# 🐛 fix: バグ修正
+# 📚 docs: ドキュメントのみの変更
+# 💎 style: コードの意味に影響しない変更（空白、書式、セミコロンの欠落など）
+# 📦 refactor: バグの修正でも機能の追加でもないコード変更
+# 🚀 perf: パフォーマンスを向上させるコード変更
+# 🚨 test: 不足しているテストの追加や既存のテストの修正
+# 🛠 build: ビルドシステムや外部の依存関係に影響する変更
+# ⚙️ ci: CI の設定ファイルやスクリプトの変更
+# ♻️ chore: src やテストファイルを変更しないその他の変更
+# 🗑 revert: 以前のコミットを取り消す


### PR DESCRIPTION
## Issue

- close #ISSUE_NUMBER 🦕

## 概要

<!-- 概要をここに記入してください。 -->

Git のコミットメッセージテンプレートを Conventional Commits に準拠した形式に変更します.

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

特になし

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

- https://www.conventionalcommits.org/ja/v1.0.0/
- https://github.com/pvdlg/conventional-changelog-metahub?tab=readme-ov-file#commit-types
- https://github.com/commitizen/conventional-commit-types

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
