### PR TITLE
fix: pubspec.yamlにおける workspace部分のインデントズレを修正

### DIFF
--- a/articles/37717d5be277ee.md
+++ b/articles/37717d5be277ee.md
@@ -53,14 +53,14 @@ find . -name "pubspec_overrides.yaml" -type f -delete
   environment:
     sdk: ^3.6.0
   
-+   workspace:
-+     - apps/app
-+     - apps/catalog
-+     - packages/cores/data
-+     - packages/cores/designsystem
-+     - packages/cores/model
-+     - packages/cores/ui
-+     - packages/features/setting
++ workspace:
++   - apps/app
++   - apps/catalog
++   - packages/cores/data
++   - packages/cores/designsystem
++   - packages/cores/model
++   - packages/cores/ui
++   - packages/features/setting
 ```
 
 各パッケージの `pubspec.yaml` には以下のように `resolution: workspace` を追加します。


### PR DESCRIPTION


## 概要

- `pubspec.yaml`における、`workspace`の記載について インデントがズレていたため修正しました



## 参考リンク

https://dart.dev/tools/pub/workspaces#:~:text=To%20create%20a%20workspace%3A を参考にしました
